### PR TITLE
Fix sql error in spawnpoint migration

### DIFF
--- a/pages/docs/other/migration.mdx
+++ b/pages/docs/other/migration.mdx
@@ -53,7 +53,7 @@ If it needs clarification, we will migrate our old RealDeviceMap spawnpoint tabl
 1. Select all spawnpoints seen in the past 14 days and save them to a file on disk. Update the database table (`rdmdb` in this example) and adjust the `WHERE` clause to your preference.
 
     ```bash
-    SELECT id, lat, lon, updated, last_seen, despawn_sec from rdmdb.spawnpoint WHERE last_seen < UNIX_TIMESTAMP() - 3600*24*14 INTO OUTFILE '/var/lib/mysql-files/spawnpoint';
+    SELECT id, lat, lon, updated, last_seen, despawn_sec, unix_timestamp() first_seen from rdmdb.spawnpoint WHERE last_seen > UNIX_TIMESTAMP() - 3600*24*14 INTO OUTFILE '/var/lib/mysql-files/spawnpoint';
     ```
 
 1. If you are moving to a new database, server, etc copy the above file `/var/lib/mysql-files/spawnpoint` to your new location.


### PR DESCRIPTION
The sql provided only migrated spawnpoints **older** then 14 days, not very useful and oposite of what the description for it said. 
Also added another column that exists in golbat but not rdm (`first_seen`).