### PR TITLE
Database config header and Rotom client note

### DIFF
--- a/pages/docs/other/database.mdx
+++ b/pages/docs/other/database.mdx
@@ -68,6 +68,8 @@ Once the database service is running, you will need to connect to the database s
 These options can help you quite significantly with performance.
 
 ```yml filename="my.cnf"
+[mysqld]
+
 # This should be 50% of RAM, leaving space for golbat
 innodb_buffer_pool_size = 64G
 

--- a/pages/docs/setup/docker.mdx
+++ b/pages/docs/setup/docker.mdx
@@ -165,6 +165,7 @@ import { Callout } from 'nextra-theme-docs'
 
     It is **highly recommended** setting a secret if Rotom is accessible from the public internet.
 
+    Please also note Rotom does not have any authentication for it's web client. It is recommended that you run this service on your internal network, behind a Firewall, or protected by a cloud based application layer.
     ```json filename="rotom_config.json"
     "deviceListener": {
       "port": 7070,


### PR DESCRIPTION
* [mysqld] header for the database config example.
* Security note for Rotom web client.